### PR TITLE
Added the correct_bad_pixels parameter in obs_nodding

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ matplotlib
 numpy
 openpyxl
 pandas
+scikit-image
 scipy
 skycalc_ipy
 typeguard


### PR DESCRIPTION
The `correct_bad_pixels` parameter in `obs_nodding` is for correcting the bad pixels in the output from `obs_nodding` by using the bad pixel map and `skimage.restoration.inpaint`. The bad pixels are left as NaN when `correct_bad_pixels=False`, but the default is set to `True`.