### PR TITLE
Save trace plots in calib/util_trace/ instead of raw/

### DIFF
--- a/pycrires/pipeline.py
+++ b/pycrires/pipeline.py
@@ -911,7 +911,7 @@ class Pipeline:
         x_range = np.arange(2048)
 
         for file_item in self.header_data[indices]["ORIGFILE"]:
-            print(f"   - raw/{file_item[:-5]}_trace.png")
+            print(f"   - calib/util_trace/{file_item[:-5]}_trace.png")
 
             with fits.open(f"{self.path}/raw/{file_item}") as hdu_list:
                 plt.figure(figsize=(10, 3.5))
@@ -996,7 +996,7 @@ class Pipeline:
                 )
 
                 plt.tight_layout()
-                plt.savefig(f"{self.path}/raw/{file_item[:-5]}_trace.png", dpi=300)
+                plt.savefig(f"{self.path}/calib/util_trace/{file_item[:-5]}_trace.png", dpi=300)
                 plt.clf()
                 plt.close()
 


### PR DESCRIPTION
I am not sure if it was intended, but all functions save their products in `calib/` except for `util_trace()`. From my point-of-view it would make more sens to keep the `raw/` directory clean and save the trace plots in `calib/`.