### PR TITLE
Manually specify spectral setting to process standalone calibrations

### DIFF
--- a/pycrires/pipeline.py
+++ b/pycrires/pipeline.py
@@ -54,7 +54,7 @@ class Pipeline:
     """
 
     @typechecked
-    def __init__(self, path: Optional[str] = None, setting = None) -> None:
+    def __init__(self, path: Optional[str] = None, setting: Optional[str] = None) -> None:
         """
         Parameters
         ----------
@@ -64,6 +64,13 @@ class Pipeline:
             (both science and calibration) from the ESO archive are
             stored. The current working folder is used if the arguments
             of ``path`` is set to ``None``.
+
+        setting : str, None
+            Specific spectral setting for which to process the calibrations.
+            This keyword is usefully if one just wants to create calibrations
+            without any SCIENCE frames. The default value is ``None``, in 
+            which case the spectral setting is infered from the SCIENCE 
+            frames.
 
         Returns
         -------

--- a/pycrires/pipeline.py
+++ b/pycrires/pipeline.py
@@ -54,7 +54,7 @@ class Pipeline:
     """
 
     @typechecked
-    def __init__(self, path: Optional[str] = None, setting: Optional[str] = None) -> None:
+    def __init__(self, path: Optional[str] = None, wavel_setting: Optional[str] = None) -> None:
         """
         Parameters
         ----------
@@ -65,7 +65,7 @@ class Pipeline:
             stored. The current working folder is used if the arguments
             of ``path`` is set to ``None``.
 
-        setting : str, None
+        wavel_setting : str, None
             Specific spectral setting for which to process the calibrations.
             This keyword is usefully if one just wants to create calibrations
             without any SCIENCE frames. The default value is ``None``, in 
@@ -93,7 +93,7 @@ class Pipeline:
 
         # manually set spectral setting
 
-        self.setting = setting
+        self.setting = wavel_setting
 
         if self.setting:
             print(f"Manually set spectral setting: {self.setting}")

--- a/pycrires/pipeline.py
+++ b/pycrires/pipeline.py
@@ -1469,7 +1469,7 @@ class Pipeline:
             json.dump(self.file_dict, json_file, indent=4)
 
     @typechecked
-    def cal_flat(self, verbose: bool = True) -> None:
+    def cal_flat(self, setting: str = None, verbose: bool = True) -> None:
         """
         Method for running ``cr2res_cal_flat``.
 
@@ -1523,8 +1523,11 @@ class Pipeline:
 
         # Wavelength setting
 
-        science_idx = np.where(self.header_data["DPR.CATG"] == "SCIENCE")[0]
-        wlen_id = self.header_data["INS.WLEN.ID"][science_idx[0]]
+        if setting is None:
+            science_idx = np.where(self.header_data["DPR.CATG"] == "SCIENCE")[0]
+            wlen_id = self.header_data["INS.WLEN.ID"][science_idx[0]]
+        else:
+            wlen_id = setting
 
         # Iterate over different DIT values for FLAT
 
@@ -1941,7 +1944,7 @@ class Pipeline:
             json.dump(self.file_dict, json_file, indent=4)
 
     @typechecked
-    def util_calib(self, calib_type: str, verbose: bool = True) -> None:
+    def util_calib(self, calib_type: str, setting: str = None, verbose: bool = True) -> None:
         """
         Method for running ``cr2res_util_calib``.
 
@@ -2047,8 +2050,11 @@ class Pipeline:
 
             dit_item = float(dit_item)
 
-        science_idx = np.where(self.header_data["DPR.CATG"] == "SCIENCE")[0]
-        wlen_id = self.header_data["INS.WLEN.ID"][science_idx[0]]
+        if setting is None:
+            science_idx = np.where(self.header_data["DPR.CATG"] == "SCIENCE")[0]
+            wlen_id = self.header_data["INS.WLEN.ID"][science_idx[0]]
+        else:
+            wlen_id = setting
 
         print(f"Creating SOF file for DIT={dit_item}:")
 
@@ -2805,7 +2811,7 @@ class Pipeline:
             json.dump(self.file_dict, json_file, indent=4)
 
     @typechecked
-    def util_genlines(self, verbose: bool = True) -> None:
+    def util_genlines(self, setting: str = None, verbose: bool = True) -> None:
         """
         Method for running ``cr2res_util_genlines``. Generate
         spectrum calibration FITS tables.
@@ -2852,9 +2858,11 @@ class Pipeline:
 
         code_dir = Path(__file__).parent
 
-        indices = np.where(self.header_data["DPR.CATG"] == "SCIENCE")[0]
-
-        wavel_set = self.header_data["INS.WLEN.ID"][indices[0]]
+        if setting is None:
+            indices = np.where(self.header_data["DPR.CATG"] == "SCIENCE")[0]
+            wavel_set = self.header_data["INS.WLEN.ID"][indices[0]]
+        else:
+            wavel_set = setting
 
         file_found = False
 
@@ -2966,8 +2974,11 @@ class Pipeline:
         fits_file = output_dir / line_file.with_suffix(".fits").name
         self._update_files("EMISSION_LINES", str(fits_file))
 
-        indices = np.where(self.header_data["DPR.CATG"] == "SCIENCE")[0]
-        wlen_id = self.header_data["INS.WLEN.ID"][indices[0]]
+        if setting is None:
+            indices = np.where(self.header_data["DPR.CATG"] == "SCIENCE")[0]
+            wlen_id = self.header_data["INS.WLEN.ID"][indices[0]]
+        else:
+            wlen_id = setting
 
         fits_file = (
             output_dir

--- a/pycrires/pipeline.py
+++ b/pycrires/pipeline.py
@@ -1245,7 +1245,7 @@ class Pipeline:
         science_index = np.where(self.header_data["DPR.CATG"] == "SCIENCE")[0]
 
         if len(science_index) > 0:
-            raise ValueError("Cannot run skycalc: there are no SCIENCE frames")
+            raise RuntimeError("Cannot run skycalc: there are no SCIENCE frames")
 
         # Requested PWV for observations
 
@@ -3591,7 +3591,7 @@ class Pipeline:
         science_idx = np.where(self.header_data["DPR.CATG"] == "SCIENCE")[0]
 
         if len(science_idx) > 0:
-            raise ValueError("Cannot run obs_staring: there are no SCIENCE frames")
+            raise RuntimeError("Cannot run obs_staring: there are no SCIENCE frames")
 
         # Wavelength setting and DIT
         science_wlen = self.header_data["INS.WLEN.ID"][science_idx[0]]
@@ -3758,7 +3758,7 @@ class Pipeline:
         science_idx = np.where(indices)[0]
 
         if len(science_idx) > 0:
-            raise ValueError("Cannot run obs_staring: there are no SCIENCE frames")
+            raise RuntimeError("Cannot run obs_staring: there are no SCIENCE frames")
 
         # Wavelength setting and DIT
         science_wlen = self.header_data["INS.WLEN.ID"][science_idx[0]]
@@ -4306,7 +4306,7 @@ class Pipeline:
         science_idx = np.where(self.header_data["DPR.CATG"] == "SCIENCE")[0]
 
         if len(science_idx) > 0:
-            raise ValueError("Cannot run obs_nodding_irregular: there are no SCIENCE frames")
+            raise RuntimeError("Cannot run obs_nodding_irregular: there are no SCIENCE frames")
 
         # Wavelength setting and DIT
         science_wlen = self.header_data["INS.WLEN.ID"][science_idx[0]]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -254,7 +254,7 @@ class TestPipeline:
             with pytest.raises(RuntimeError) as error:
                 self.pipeline.obs_nodding(verbose=False)
 
-            assert str(error.value) == "Cannot run obs_nodding: there are no SCIENCE frames"
+            assert str(error.value) == "ValueError: Cannot run obs_nodding: there are no SCIENCE frames"
 
         else:
             self.pipeline.obs_nodding(verbose=False)
@@ -264,7 +264,7 @@ class TestPipeline:
         with pytest.raises(RuntimeError) as error:
             self.pipeline.run_skycalc(pwv=1.0)
 
-        assert str(error.value) == "Cannot run skycalc: there are no SCIENCE frames"
+        assert str(error.value) == "ValueError: Cannot run skycalc: there are no SCIENCE frames"
 
     def test_plot_spectra(self) -> None:
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -254,14 +254,17 @@ class TestPipeline:
             with pytest.raises(RuntimeError) as error:
                 self.pipeline.obs_nodding(verbose=False)
 
-            assert str(error.value) == self.esorex_error
+            assert str(error.value) == "Cannot run obs_nodding: there are no SCIENCE frames"
 
         else:
             self.pipeline.obs_nodding(verbose=False)
 
     def test_run_skycalc(self) -> None:
 
-        self.pipeline.run_skycalc(pwv=1.0)
+        with pytest.raises(RuntimeError) as error:
+            self.pipeline.run_skycalc(pwv=1.0)
+
+        assert str(error.value) == "Cannot run skycalc: there are no SCIENCE frames"
 
     def test_plot_spectra(self) -> None:
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -254,7 +254,7 @@ class TestPipeline:
             with pytest.raises(RuntimeError) as error:
                 self.pipeline.obs_nodding(verbose=False)
 
-            assert str(error.value) == "Cannot run obs_nodding: there are no SCIENCE frames"
+                assert str(error.value) == "Cannot run obs_nodding: there are no SCIENCE frames"
 
         else:
             self.pipeline.obs_nodding(verbose=False)
@@ -264,7 +264,7 @@ class TestPipeline:
         with pytest.raises(RuntimeError) as error:
             self.pipeline.run_skycalc(pwv=1.0)
 
-        assert str(error.value) == "Cannot run skycalc: there are no SCIENCE frames"
+            assert str(error.value) == "Cannot run skycalc: there are no SCIENCE frames"
 
     def test_plot_spectra(self) -> None:
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -254,7 +254,7 @@ class TestPipeline:
             with pytest.raises(RuntimeError) as error:
                 self.pipeline.obs_nodding(verbose=False)
 
-            assert str(error.value) == "ValueError: Cannot run obs_nodding: there are no SCIENCE frames"
+            assert str(error.value) == "Cannot run obs_nodding: there are no SCIENCE frames"
 
         else:
             self.pipeline.obs_nodding(verbose=False)
@@ -264,7 +264,7 @@ class TestPipeline:
         with pytest.raises(RuntimeError) as error:
             self.pipeline.run_skycalc(pwv=1.0)
 
-        assert str(error.value) == "ValueError: Cannot run skycalc: there are no SCIENCE frames"
+        assert str(error.value) == "Cannot run skycalc: there are no SCIENCE frames"
 
     def test_plot_spectra(self) -> None:
 


### PR DESCRIPTION
Hi @tomasstolker,
Here is another suggestion to enable processing calibrations in a standalone mode, i.e. with no SCIENCE frames. This is quite specific for HiRISE where we do no use `obs_nodding` or `obs_staring`. We just use the pipeline to generate the daily calibrations and then we use our own routines. The implementation is really straightforward: an optional `setting` parameter can be passed to `__init__`. If the keyword is passed at the creation of the instances it is then used for processing the calibrations, otherwise the setting is inferred from the SCIENCE frames. I don't think it has any side effect compared to the current implementation when SCIENCE frames are present. Again, feel free to reject the pull request if you think it is not appropriate.